### PR TITLE
infeasibility fix and mccormick bound parameters

### DIFF
--- a/src/agents/utility.jl
+++ b/src/agents/utility.jl
@@ -1119,7 +1119,7 @@ function solve_agent_problem!(
 
     ####### fix variables to reasonable range #######
     for y in model_data.index_y, z in model_data.index_z
-        set_upper_bound(x_R[y, Symbol("nuclear"), z], 1.0)
+        set_upper_bound(x_R[y, Symbol("nuclear"), z], 0.0)
         # fix(x_R[y, :nuclear, z], 0.0, force=true)
         # set_upper_bound(x_C[y, Symbol("lfill-gas"), z], 10.0)
         # set_upper_bound(x_C[y, Symbol("coaloldscr"), z], 10.0)


### PR DESCRIPTION
This PR includes the following:
- a set of parameters generating the McCormick bounds that solved all 15-year WM problems with PTC & ITC
- updated parameters in lower-level LP problems to improve feasibility
- @HaleyRoss I reversed the `repeat([[]], 24)...` because I don't think it's working properly. When I was checking, for example, `ipp.eta_L_vec`, it has other vectors in addition to `eta_L`. Could you please look into that?