### PR TITLE
Run HEM with DistributionUtility agent

### DIFF
--- a/src/run_hem.jl
+++ b/src/run_hem.jl
@@ -34,7 +34,7 @@ function run_hem(
     ipp = IPPGroup(input_dir, model_data)
     green_developer = GreenDeveloper(input_dir, model_data)
     dera = DERAggregator(input_dir, model_data, dera_options)
-    # distribution_utility = DistributionUtility(input_dir, model_data)
+    distribution_utility = DistributionUtility(input_dir, model_data)
 
     # the sequence of simulation matters a lot! (e.g., the year DER aggregation is picked is dependent on this)
     agents_and_opts = [
@@ -44,7 +44,7 @@ function run_hem(
         AgentAndOptions(customers, customer_options),
         AgentAndOptions(green_developer, green_developer_options),
         AgentAndOptions(dera, dera_options),
-        # AgentAndOptions(distribution_utility, NullAgentOptions()),
+        AgentAndOptions(distribution_utility, NullAgentOptions()),
     ]
 
     output_dir = joinpath(input_dir, get_file_prefix(options, agents_and_opts))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,7 +298,7 @@ end
 
 function read_dataframe(::Type{CSV.File}, filename::AbstractString)
     open(filename) do io
-        CSV.read(io, DataFrame)
+        CSV.read(io, DataFrame, delim = ",")
     end
 end
 


### PR DESCRIPTION
1. Uncommented `DistributionUtility` agent in `run_hem`.
2. Fixed indexing of certain parameters in `existing_distribution_account` and `new_distribution_account`. 
3. Updated the calculation of normalized `distribution_capex_balance_norm`, `distribution_capex_addition_norm` and `distribution_om_cost_norm`.
4. Fixed parsing error for TransmissionTopology.csv.

*TODO*
With these changes it is able to solve the agent problem and complete the run. But, currently, there are no `DistributionUtilityOptions` defined. Also, there is no `save_results` method defined.