### PR TITLE
added delimiter to read_dataframe

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,7 +298,7 @@ end
 
 function read_dataframe(::Type{CSV.File}, filename::AbstractString)
     open(filename) do io
-        CSV.read(io, DataFrame)
+        CSV.read(io, DataFrame, delim = ",")
     end
 end
 


### PR DESCRIPTION
By default `CSV.read()` tries to guess the delimiter from the first 10 characters in the file. In the case of running for two BAs the TransmissionTopology.csv file only contained a single column `p129||p130` which was parsed as `p129, Column2, p130` causing an error. Explicitly specifying the delimiter solves the issue.